### PR TITLE
MAINT: update jinja call for pulling plugin version from conda env

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: q2-vizard
-  version: {{ PKG_VERSION }}
+  version: {{ PLUGIN_VERSION }}
 
 source:
   path: ../..
 
 build:
   script-env:
-    - PKG_VERSION={{ environ.get('PKG_VERSION', '0.0.0') }}
+    - PLUGIN_VERSION
   script: {{ PYTHON }} -m pip install -v .
 
 requirements:

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -7,7 +7,10 @@ source:
 
 build:
   script: |
-    echo "pkg version: {{ environ.get('PKG_VERSION') }}"
+    echo "ENVIRONMENT VARIABLES:"
+    {% for key, value in environ.items() %}
+    echo "{{ key }} = {{ value }}"
+    {% endfor %}
     {{ PYTHON }} -m pip install -v .
 
 requirements:

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -7,7 +7,7 @@ source:
 
 build:
   script-env:
-    - PKG_VERSION={{ environ.get('PKG_VERSION') }}
+    - PKG_VERSION={{ environ.get('PKG_VERSION', '0.0.0') }}
   script: {{ PYTHON }} -m pip install -v .
 
 requirements:

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     # in order to render out transpiled js assets for various visualizations.
     # once rendered, node is no longer necessary. don't set this in host reqs.
     - nodejs
+    - versioneer
 
   host:
     - python {{ python }}
@@ -24,7 +25,7 @@ requirements:
     - setuptools
     # now that we're not vendoring versioneer, we need to add it into the host
     # reqs in order for it to get added to the conda env for build pkg step
-    - versioneer
+    # - versioneer
 
   run:
     - python {{ python }}

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -7,7 +7,7 @@ source:
 
 build:
   script: |
-    echo "ENVIRONMENT VARIABLES:"
+    echo "ENVIRONMENT VARIABLES DURING CONDA BUILD"
     {% for key, value in environ.items() %}
     echo "{{ key }} = {{ value }}"
     {% endfor %}

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -1,17 +1,14 @@
 package:
   name: q2-vizard
-  version: {{ environ.get('PKG_VERSION') }}
+  version: {{ PKG_VERSION }}
 
 source:
   path: ../..
 
 build:
-  script: |
-    echo "ENVIRONMENT VARIABLES DURING CONDA BUILD"
-    {% for key, value in environ.items() %}
-    echo "{{ key }} = {{ value }}"
-    {% endfor %}
-    {{ PYTHON }} -m pip install -v .
+  script-env:
+    - PKG_VERSION
+  script: {{ PYTHON }} -m pip install -v .
 
 requirements:
   build:

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -1,9 +1,6 @@
-{% set data = load_setup_py_data() %}
-{% set version = data.get('version') or 'placehold' %}
-
 package:
   name: q2-vizard
-  version: {{ version }}
+  version: {{ environ.get('PKG_VERSION') }}
 
 source:
   path: ../..
@@ -17,7 +14,6 @@ requirements:
     # in order to render out transpiled js assets for various visualizations.
     # once rendered, node is no longer necessary. don't set this in host reqs.
     - nodejs
-    - versioneer
 
   host:
     - python {{ python }}
@@ -25,7 +21,7 @@ requirements:
     - setuptools
     # now that we're not vendoring versioneer, we need to add it into the host
     # reqs in order for it to get added to the conda env for build pkg step
-    # - versioneer
+    - versioneer
 
   run:
     - python {{ python }}

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set pkg_data = load_file_data('../../../../report.json') %}
-{% set version = pkg_data['install'][0]['metadata']['version'] %}
+{% set data = load_setup_py_data() %}
+{% set version = data.get('version') or 'placehold' %}
 
 package:
   name: q2-vizard
@@ -22,6 +22,8 @@ requirements:
     - python {{ python }}
     - pip
     - setuptools
+    # now that we're not vendoring versioneer, we need to add it into the host
+    # reqs in order for it to get added to the conda env for build pkg step
     - versioneer
 
   run:

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -7,7 +7,7 @@ source:
 
 build:
   script-env:
-    - PKG_VERSION
+    - PKG_VERSION={{ environ.get('PKG_VERSION') }}
   script: {{ PYTHON }} -m pip install -v .
 
 requirements:

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -6,7 +6,9 @@ source:
   path: ../..
 
 build:
-  script: {{ PYTHON }} -m pip install -v .
+  script: |
+    echo "pkg version: {{ environ.get('PKG_VERSION') }}"
+    {{ PYTHON }} -m pip install -v .
 
 requirements:
   build:


### PR DESCRIPTION
this updates the method for pulling the plugin version - instead of using the location on the runner for the report.json file, an environment variable `PLUGIN_VERSION` is added into the conda env and then pulled during build time.

associated update in ALP: https://github.com/qiime2/action-library-packaging/blob/5e1a11bbd26398ff2c36652c659303b757c44bf3/build-package/bin/build-package.py#L86-L91