### PR TITLE
BUG: TypeError in scatterplot_2d list indexing

### DIFF
--- a/q2_vizard/scatterplot.py
+++ b/q2_vizard/scatterplot.py
@@ -41,7 +41,7 @@ def scatterplot_2d(output_dir: str, metadata: Metadata,
     if color_by_group:
         group_dropdown_default = color_by_group
     else:
-        group_dropdown_default = md_cols_categorical['legendDefault']
+        group_dropdown_default = 'legendDefault'
 
     # handling numeric columns for x/y plotting
     md_cols_numeric = \


### PR DESCRIPTION
Fixes #27 

Fixed a TypeError in the scatterplot_2d function by correcting the list indexing for setting the group dropdown default. Now the code properly assigns 'legendDefault' without causing indexing issues.
