### PR TITLE
NEW: refactored FMT heatmap for more generalized use

### DIFF
--- a/q2_vizard/__init__.py
+++ b/q2_vizard/__init__.py
@@ -7,10 +7,10 @@
 # ----------------------------------------------------------------------------
 
 from ._version import get_versions
-from .heatmap import plot_heatmap
+from .heatmap import heatmap
 from .scatterplot import scatterplot_2d
 
 __version__ = get_versions()['version']
 del get_versions
 
-__all__ = ['plot_heatmap', 'scatterplot_2d']
+__all__ = ['heatmap', 'scatterplot_2d']

--- a/q2_vizard/assets/heatmap/spec.json
+++ b/q2_vizard/assets/heatmap/spec.json
@@ -149,6 +149,9 @@
           "fill": {
             "scale": "color",
             "field": {"{{REPLACE_PARAM}}": "gradient_measure"}
+          },
+          "stroke": {
+            "value": "white"
           }
         }
       }

--- a/q2_vizard/assets/heatmap/spec.json
+++ b/q2_vizard/assets/heatmap/spec.json
@@ -56,7 +56,8 @@
       "type": "band",
       "domain": {
         "data": "table",
-        "field": {"{{REPLACE_PARAM}}": "x_measure"}
+        "field": {"{{REPLACE_PARAM}}": "x_measure"},
+        "sort": true
       },
       "range": "width"
     },
@@ -65,7 +66,8 @@
       "type": "band",
       "domain": {
         "data": "table",
-        "field": {"{{REPLACE_PARAM}}": "y_measure"}
+        "field": {"{{REPLACE_PARAM}}": "y_measure"},
+        "sort": true
       },
       "range": "height"
     },

--- a/q2_vizard/assets/heatmap/spec.json
+++ b/q2_vizard/assets/heatmap/spec.json
@@ -11,9 +11,32 @@
     "type": "pad",
     "resize": true
   },
-  "width": 900,
-  "height": 900,
+  "width": {"signal": "columnWidth * nColumns"},
+  "height": {"signal": "rowHeight * nRows"},
   "padding": 20,
+
+  "data": [
+    {
+      "name": "table",
+      "values": {"{{REPLACE_PARAM}}": "metadata"}
+    },
+    {
+      "name": "rowTable",
+      "source": "table",
+      "transform": [{
+        "type": "aggregate",
+        "groupby": [{"{{REPLACE_PARAM}}": "y_measure"}]
+      }]
+    },
+    {
+      "name": "columnTable",
+      "source": "table",
+      "transform": [{
+        "type": "aggregate",
+        "groupby": [{"{{REPLACE_PARAM}}": "x_measure"}]
+      }]
+    }
+  ],
 
   "signals": [
     {
@@ -32,21 +55,37 @@
       "bind": {
         "input": "select",
         "options": [
-          "Inferno",
-          "Viridis",
-          "Magma",
-          "Greys",
-          "Plasma",
-          "Cividis"
+          "Inferno", "Viridis", "Magma", "Greys", "Plasma", "Cividis"
         ]
       }
-    }
-  ],
-
-  "data": [
+    },
     {
-      "name": "table",
-      "values": {"{{REPLACE_PARAM}}": "metadata"}
+      "name": "nRows",
+      "value": 1,
+      "update": "length(data('rowTable'))"
+    },
+    {
+      "name": "nColumns",
+      "value": 1,
+      "update": "length(data('columnTable'))"
+    },
+    {
+      "name": "rowHeight",
+      "value": 45,
+      "bind": {
+        "input": "range",
+        "min": 5,
+        "max": 200
+      }
+    },
+    {
+      "name": "columnWidth",
+      "value": 45,
+      "bind": {
+        "input": "range",
+        "min": 5,
+        "max": 200
+      }
     }
   ],
 
@@ -61,7 +100,7 @@
           "order": "ascending"
         }
       },
-      "range": "width"
+      "range": [0, {"signal": "columnWidth * nColumns"}]
     },
     {
       "name": "y_scale",
@@ -73,7 +112,7 @@
           "order": "descending"
         }
       },
-      "range": "height"
+      "range": [0, {"signal": "rowHeight * nRows"}]
     },
     {
       "name": "color",
@@ -117,7 +156,7 @@
       "title": {"{{REPLACE_PARAM}}": "gradient_measure"},
       "titleFontSize": 12,
       "titlePadding": 4,
-      "gradientLength": {"signal": "height - 16"}
+      "gradientLength": {"signal": "(rowHeight * nRows) - 16"}
     }
   ],
 
@@ -126,7 +165,7 @@
       "type": "rect",
       "from": {"data": "table"},
       "encode": {
-        "enter": {
+        "update": {
           "x": {
             "scale": "x_scale",
             "field": {"{{REPLACE_PARAM}}": "x_measure"}
@@ -143,16 +182,14 @@
             "scale": "y_scale",
             "band": 1
           },
-          "tooltip": {"signal": "datum"}
-        },
-        "update": {
           "fill": {
             "scale": "color",
             "field": {"{{REPLACE_PARAM}}": "gradient_measure"}
           },
           "stroke": {
             "value": "white"
-          }
+          },
+          "tooltip": {"signal": "datum"}
         }
       }
     }

--- a/q2_vizard/assets/heatmap/spec.json
+++ b/q2_vizard/assets/heatmap/spec.json
@@ -57,7 +57,9 @@
       "domain": {
         "data": "table",
         "field": {"{{REPLACE_PARAM}}": "x_measure"},
-        "sort": true
+        "sort": {
+          "order": "ascending"
+        }
       },
       "range": "width"
     },
@@ -67,7 +69,9 @@
       "domain": {
         "data": "table",
         "field": {"{{REPLACE_PARAM}}": "y_measure"},
-        "sort": true
+        "sort": {
+          "order": "descending"
+        }
       },
       "range": "height"
     },

--- a/q2_vizard/assets/heatmap/spec.json
+++ b/q2_vizard/assets/heatmap/spec.json
@@ -1,105 +1,151 @@
 {
-    "$schema": "https://vega.github.io/schema/vega/v5.json",
-    "description": "A Basic Heatmap",
-    "width": {"signal": "ncolumns * columnwidth"},
-    "height": {"signal": "nrows * rowheight"},
-    "padding": 0,
-    "title": {"text": {"signal": "title"}},
-    "data": [
-      {"name": "table",
-       "values": {"{{REPLACE_PARAM}}": "data"}
-      },
-      {
-        "name": "rowtable",
-        "source": "table",
-        "transform": [{"type": "aggregate", "groupby": [{"{{REPLACE_PARAM}}": "y_label"}]}]
-      },
-      {
-        "name": "columntable",
-        "source": "table",
-        "transform": [{"type": "aggregate", "groupby": [{"{{REPLACE_PARAM}}": "x_label"}]}]
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "title": {
+    "text": {"signal": "title"},
+    "fontSize": 20,
+    "orient": "top",
+    "anchor": "start",
+    "subtitle": " "
+  },
+  "autosize": {
+    "type": "pad",
+    "resize": true
+  },
+  "width": 900,
+  "height": 900,
+  "padding": 20,
+
+  "signals": [
+    {
+      "name": "title",
+      "value": {"{{REPLACE_PARAM}}": "title"},
+      "bind": {"input": "input"}
+    },
+    {
+      "name": "invertGradient",
+      "value": false,
+      "bind": {"input": "checkbox"}
+    },
+    {
+      "name": "gradientPalette",
+      "value": "Viridis",
+      "bind": {
+        "input": "select",
+        "options": [
+          "Inferno",
+          "Viridis",
+          "Magma",
+          "Greys",
+          "Plasma",
+          "Cividis"
+        ]
       }
-    ],
-    "signals": [
-      {
-        "name": "palette",
-        "value": "Viridis",
-        "bind": {
-          "input": "select",
-          "options": ["Inferno", "Viridis", "Magma", "Greys", "Plasma", "Cividis"]
-        }
+    }
+  ],
+
+  "data": [
+    {
+      "name": "table",
+      "values": {"{{REPLACE_PARAM}}": "metadata"}
+    }
+  ],
+
+  "scales": [
+    {
+      "name": "x_scale",
+      "type": "band",
+      "domain": {
+        "data": "table",
+        "field": {"{{REPLACE_PARAM}}": "x_measure"}
       },
-      {"name": "nrows", "value": 1, "update": "length(data(\"rowtable\"))"},
-      {
-        "name": "rowheight",
-        "value": 15,
-        "bind": {"input": "range", "min": 5, "max": 100}
+      "range": "width"
+    },
+    {
+      "name": "y_scale",
+      "type": "band",
+      "domain": {
+        "data": "table",
+        "field": {"{{REPLACE_PARAM}}": "y_measure"}
       },
-      {"name": "ncolumns", "value": 1, "update": "length(data(\"columntable\"))"},
-      {
-        "name": "columnwidth",
-        "value": 30,
-        "bind": {"input": "range", "min": 5, "max": 100 }
-      },
-      {"name": "title", "value": {"{{REPLACE_PARAM}}": "title"}, "bind": {"input": "input"}},
-      {"name": "y_label", "value": {"{{REPLACE_PARAM}}": "y_label_name"}, "bind": {"input": "input"}},
-      {"name": "x_label", "value": {"{{REPLACE_PARAM}}": "x_label_name"}, "bind": {"input": "input"}}
-    ],
-    "scales": [
-      {
-        "name": "Y_label",
-        "type": "band",
-        "domain": {"data": "table", "field": {"{{REPLACE_PARAM}}": "y_label"}},
-        "range": "height",
-        "paddingInner": 0.05
-      },
-      {
-        "name": "X_label",
-        "type": "band",
-        "domain": {"data": "table", "field": {"{{REPLACE_PARAM}}": "x_label"}, 
-                    "sort":{"{{REPLACE_PARAM}}": "order"}},
-        "range": "width",
-        "paddingInner": 0.01
-      },
-      {
-        "name": "color",
-        "type": "sequential",
-        "domain": {"data": "table", "field": {"{{REPLACE_PARAM}}": "measure"}},
-        "range": {"scheme": {"signal": "palette"}}
-      }
-    ],
-    "axes": [
-      {"scale": "Y_label", "orient": "left", "title":{"signal": "y_label"}},
-      {"scale": "X_label", "orient": "bottom", "title":{"signal": "x_label"}}
-    ],
-    "marks": [
-      {
-        "type": "rect",
-        "from": {"data": "table"},
-        "encode": {
-          "update": {
-            "y": {"field": {"{{REPLACE_PARAM}}": "y_label"}, "scale": "Y_label"},
-            "x": {"field": {"{{REPLACE_PARAM}}": "x_label"}, "scale": "X_label"},
-            "height": {"band": 1, "scale": "Y_label"},
-            "width": {"band": 1, "scale": "X_label"},
-            "fill": {"scale": "color", "field": {"{{REPLACE_PARAM}}": "measure"}},
-            "tooltip": {
-              "signal": "datum"
-            }
+      "range": "height"
+    },
+    {
+      "name": "color",
+      "type": "linear",
+      "range": {
+        "scheme": {"signal": "gradientPalette"}},
+      "domain": {
+        "data": "table",
+        "field": {"{{REPLACE_PARAM}}": "gradient_measure"}},
+      "reverse": {"signal": "invertGradient"},
+      "zero": false, "nice": true
+    }
+  ],
+
+  "axes": [
+    {
+      "scale": "x_scale",
+      "labelFontSize": 12,
+      "grid": true,
+      "orient": "bottom",
+      "tickCount": 5,
+      "title": {"{{REPLACE_PARAM}}": "x_measure"},
+      "titleFontSize": 14,
+      "titlePadding": 20
+    },
+    {
+      "scale": "y_scale",
+      "labelFontSize": 12,
+      "grid": true,
+      "orient": "left",
+      "title": {"{{REPLACE_PARAM}}": "y_measure"},
+      "titleFontSize": 14,
+      "titlePadding": 20
+    }
+  ],
+
+  "legends": [
+    {
+      "fill": "color",
+      "type": "gradient",
+      "title": {"{{REPLACE_PARAM}}": "gradient_measure"},
+      "titleFontSize": 12,
+      "titlePadding": 4,
+      "gradientLength": {"signal": "height - 16"}
+    }
+  ],
+
+  "marks": [
+    {
+      "type": "rect",
+      "from": {"data": "table"},
+      "encode": {
+        "enter": {
+          "x": {
+            "scale": "x_scale",
+            "field": {"{{REPLACE_PARAM}}": "x_measure"}
+          },
+          "y": {
+            "scale": "y_scale",
+            "field": {"{{REPLACE_PARAM}}": "y_measure"}
+          },
+          "width": {
+            "scale": "x_scale",
+            "band": 1
+          },
+          "height": {
+            "scale": "y_scale",
+            "band": 1
+          },
+          "tooltip": {"signal": "datum"}
+        },
+        "update": {
+          "fill": {
+            "scale": "color",
+            "field": {"{{REPLACE_PARAM}}": "gradient_measure"}
           }
         }
       }
-    ],
-    "legends": [
-      {
-        "fill": "color",
-        "type": "gradient",
-        "title": {"{{REPLACE_PARAM}}": "measure_name"},
-        "titleFontSize": 12,
-        "titlePadding": 4,
-        "gradientLength": {"signal": "250"}
-      }
-    ],
-    "config": {}
-  }
-  
+    }
+  ]
+}

--- a/q2_vizard/heatmap.py
+++ b/q2_vizard/heatmap.py
@@ -13,7 +13,7 @@ import pkg_resources
 
 from qiime2 import Metadata, MetadataColumn, NumericMetadataColumn
 
-from ._util import _json_replace, _measure_validation
+from ._util import _json_replace, _col_type_validation, _measure_validation
 
 
 def heatmap(output_dir: str, metadata: Metadata,
@@ -25,10 +25,14 @@ def heatmap(output_dir: str, metadata: Metadata,
     # input handling for initial metadata
     md = metadata.to_dataframe().reset_index()
 
-    # measure validation for gradient_measure
-    _measure_validation(metadata=metadata,
-                        measure=gradient_measure,
-                        col_type='numeric')
+    # md validation for all input measures
+    for measure in [x_measure, y_measure, gradient_measure]:
+        _measure_validation(metadata=metadata, measure=measure)
+
+    # col type validation for gradient_measure
+    _col_type_validation(metadata=metadata,
+                         measure=gradient_measure,
+                         col_type='numeric')
 
     # jinja templating & JSON-ifying
     J_ENV = jinja2.Environment(

--- a/q2_vizard/heatmap.py
+++ b/q2_vizard/heatmap.py
@@ -11,25 +11,24 @@ import jinja2
 import json
 import pkg_resources
 
-from qiime2 import Metadata, NumericMetadataColumn
+from qiime2 import Metadata, MetadataColumn, NumericMetadataColumn
 
 from ._util import _json_replace, _measure_validation
 
 
 def heatmap(output_dir: str, metadata: Metadata,
-            x_measure: NumericMetadataColumn,
-            y_measure: NumericMetadataColumn,
+            x_measure: MetadataColumn,
+            y_measure: MetadataColumn,
             gradient_measure: NumericMetadataColumn,
             title: str = None):
 
     # input handling for initial metadata
     md = metadata.to_dataframe().reset_index()
 
-    # measure validation for all three numeric inputs
-    for measure in [x_measure, y_measure, gradient_measure]:
-        _measure_validation(
-            metadata=metadata, measure=measure, col_type='numeric'
-        )
+    # measure validation for gradient_measure
+    _measure_validation(metadata=metadata,
+                        measure=gradient_measure,
+                        col_type='numeric')
 
     # jinja templating & JSON-ifying
     J_ENV = jinja2.Environment(

--- a/q2_vizard/plugin_setup.py
+++ b/q2_vizard/plugin_setup.py
@@ -6,10 +6,9 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime2.plugin import Plugin, Metadata, Str, Choices, Bool
-from q2_stats._type import Dist1D, Matched, Ordered
+from qiime2.plugin import Plugin, Str, Metadata
 
-from q2_vizard.heatmap import plot_heatmap
+from q2_vizard.heatmap import heatmap
 from q2_vizard.scatterplot import scatterplot_2d
 
 
@@ -23,14 +22,30 @@ plugin = Plugin(name='vizard',
 
 
 plugin.visualizers.register_function(
-    function=plot_heatmap,
-    inputs={'data': Dist1D[Ordered, Matched]},
+    function=heatmap,
+    inputs={},
     parameters={
-        'transpose': Bool,
-        'order': Str % Choices('ascending', 'descending')
+        'metadata': Metadata,
+        'x_measure': Str,
+        'y_measure': Str,
+        'gradient_measure': Str,
+        'title': Str
     },
-    name='Plot Heatmap',
-    description='',
+    name='Heatmap',
+    description={
+        'Basic heatmap for visualizing three numeric Metadata measures.'
+    },
+    parameter_descriptions={
+        'metadata': 'Any metadata-like input that contains at least three'
+                    ' numeric measures for visualizing.',
+        'x_measure': 'Numeric measure from the input Metadata that should be'
+                     ' plotted on the x-axis.',
+        'y_measure': 'Numeric measure from the input Metadata that should be'
+                     ' plotted on the y-axis.',
+        'gradient_measure': 'Numeric measure from the input Metadata that'
+                            ' should be used to represent the color gradient'
+                            ' in the heatmap.',
+        'title': 'The title of the heatmap.'}
 )
 
 

--- a/q2_vizard/plugin_setup.py
+++ b/q2_vizard/plugin_setup.py
@@ -32,15 +32,14 @@ plugin.visualizers.register_function(
         'title': Str
     },
     name='Heatmap',
-    description='Basic heatmap for visualizing '
-                'three numeric Metadata measures.',
+    description='Basic heatmap for visualizing three Metadata measures.',
     parameter_descriptions={
         'metadata': 'Any metadata-like input that contains at least three'
-                    ' numeric measures for visualizing.',
-        'x_measure': 'Numeric measure from the input Metadata that should be'
-                     ' plotted on the x-axis.',
-        'y_measure': 'Numeric measure from the input Metadata that should be'
-                     ' plotted on the y-axis.',
+                    ' measures for visualizing, one of which must be numeric.',
+        'x_measure': 'Numeric or categorical measure from the input Metadata'
+                     ' that should be plotted on the x-axis.',
+        'y_measure': 'Numeric or categorical measure from the input Metadata'
+                     ' that should be plotted on the y-axis.',
         'gradient_measure': 'Numeric measure from the input Metadata that'
                             ' should be used to represent the color gradient'
                             ' in the heatmap.',

--- a/q2_vizard/plugin_setup.py
+++ b/q2_vizard/plugin_setup.py
@@ -32,9 +32,8 @@ plugin.visualizers.register_function(
         'title': Str
     },
     name='Heatmap',
-    description={
-        'Basic heatmap for visualizing three numeric Metadata measures.'
-    },
+    description='Basic heatmap for visualizing '
+                'three numeric Metadata measures.',
     parameter_descriptions={
         'metadata': 'Any metadata-like input that contains at least three'
                     ' numeric measures for visualizing.',

--- a/q2_vizard/scatterplot.py
+++ b/q2_vizard/scatterplot.py
@@ -12,7 +12,7 @@ import pkg_resources
 import jinja2
 
 from qiime2 import Metadata, NumericMetadataColumn, CategoricalMetadataColumn
-from ._util import _json_replace, _measure_validation
+from ._util import _json_replace, _col_type_validation, _measure_validation
 
 
 def scatterplot_2d(output_dir: str, metadata: Metadata,
@@ -32,8 +32,9 @@ def scatterplot_2d(output_dir: str, metadata: Metadata,
 
     # validation for group measure
     if color_by_group:
-        _measure_validation(metadata=metadata, measure=color_by_group,
-                            col_type='categorical')
+        _measure_validation(metadata=metadata, measure=color_by_group)
+        _col_type_validation(metadata=metadata, measure=color_by_group,
+                             col_type='categorical')
 
     # setting default (or selected) group measure for color-coding
     # and adding 'none' for removing color-coding
@@ -50,15 +51,17 @@ def scatterplot_2d(output_dir: str, metadata: Metadata,
 
     # validation for x/y measures
     if x_measure:
-        _measure_validation(metadata=metadata, measure=x_measure,
-                            col_type='numeric')
+        _measure_validation(metadata=metadata, measure=x_measure)
+        _col_type_validation(metadata=metadata, measure=x_measure,
+                             col_type='numeric')
         x_dropdown_default = x_measure
     else:
         x_dropdown_default = md_cols_numeric[0]
 
     if y_measure:
-        _measure_validation(metadata=metadata, measure=y_measure,
-                            col_type='numeric')
+        _measure_validation(metadata=metadata, measure=y_measure)
+        _col_type_validation(metadata=metadata, measure=y_measure,
+                             col_type='numeric')
         y_dropdown_default = y_measure
     else:
         y_dropdown_default = md_cols_numeric[0]


### PR DESCRIPTION
This is a refactored heatmap from @cherman2's PEDS heatmap in q2-fmt. It accepts three numeric metadata columns as input. It doesn't currently support drop downs to change the numeric fields that are represented, but that can be added as well.