### PR TITLE
IMP: adds y-dropdown to lineplot

### DIFF
--- a/q2_vizard/assets/lineplot/spec.json
+++ b/q2_vizard/assets/lineplot/spec.json
@@ -43,7 +43,11 @@
     },
     {
       "name": "yField",
-      "value": {"{{REPLACE_PARAM}}": "y_measure"}
+      "value": {"{{REPLACE_PARAM}}": "y_measure"},
+      "bind": {
+        "input": "select",
+        "options": {"{{REPLACE_PARAM}}": "md_cols_numeric"}
+      }
     }
   ],
 
@@ -78,7 +82,7 @@
       "zero": true,
       "domain": {
         "data": "scatter_table",
-        "field": {"{{REPLACE_PARAM}}": "y_measure"}
+        "field": {"signal": "yField"}
       }
     },
     {
@@ -109,7 +113,7 @@
       "labelFontSize": 12,
       "grid": true,
       "orient": "left",
-      "title": {"{{REPLACE_PARAM}}": "y_measure"},
+      "title": {"signal": "yField"},
       "titleFontSize": 14,
       "titlePadding": 20
     }
@@ -159,7 +163,7 @@
               },
               "y": {
                 "scale": "y_scale",
-                "field": {"{{REPLACE_PARAM}}": "y_measure"}},
+                "field": {"signal": "yField"}},
               "interpolate": {"signal": "lineType"},
               "stroke": {
                 "scale": "color_scale",
@@ -183,7 +187,7 @@
           },
           "y": {
             "scale": "y_scale",
-            "field": {"{{REPLACE_PARAM}}": "y_measure"}
+            "field": {"signal": "yField"}
           },
           "shape": {"value": "circle"},
           "stroke": {

--- a/q2_vizard/lineplot.py
+++ b/q2_vizard/lineplot.py
@@ -39,6 +39,11 @@ def lineplot(output_dir: str, metadata: Metadata,
                          ' Please choose different columns in your'
                          ' metadata for these measures.')
 
+    # filtering md cols for the y-axis dropdown
+    md_cols_numeric = \
+        metadata.filter_columns(column_type='numeric').to_dataframe()
+    md_cols_numeric = list(md_cols_numeric)
+
     # column validation for grouping
     if group_by:
         _col_type_validation(metadata=metadata, measure=group_by,
@@ -123,11 +128,11 @@ def lineplot(output_dir: str, metadata: Metadata,
         if replicate_method == 'median':
             averaged_md = \
                 (ordered_md.groupby([x_measure, group_by],
-                                    as_index=False)[y_measure].median())
+                                    as_index=False)[md_cols_numeric].median())
         elif replicate_method == 'mean':
             averaged_md = \
                 (ordered_md.groupby([x_measure, group_by],
-                                    as_index=False)[y_measure].mean())
+                                    as_index=False)[md_cols_numeric].mean())
 
         averaged_md = averaged_md.sort_values(by=[group_by, x_measure])
 
@@ -154,6 +159,7 @@ def lineplot(output_dir: str, metadata: Metadata,
     full_spec = \
         _json_replace(json_obj, metadata=md_obj, md_ids=md_ids,
                       averaged_metadata=averaged_md_obj,
+                      md_cols_numeric=md_cols_numeric,
                       x_measure=x_measure, y_measure=y_measure,
                       group_by=group_by, title=title, subtitle=subtitle)
 


### PR DESCRIPTION
This PR updates the implementation of lineplot so that the Y-axis is connected to a dropdown, which allows users to toggle through viewing all numeric md columns as a function of X. This update was required for https://github.com/bokulich-lab/RESCRIPt/pull/204